### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # License: MIT                                                                    #
 #                                                                                 #
 ###################################################################################
-cmake_minimum_required(VERSION 3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 
 project(unity LANGUAGES C DESCRIPTION "C Unit testing framework.")


### PR DESCRIPTION
Update the CMAKE minimum version from `3` to `3.0` to fix error in Windows 10 x64 with CMAKE 3.15.4:

`cmake_minimum_required could not parse VERSION "3".`